### PR TITLE
able to fetch attached iam policies and config rules

### DIFF
--- a/src/tests/config_rules_sample.json
+++ b/src/tests/config_rules_sample.json
@@ -1,0 +1,32 @@
+{
+  "ConfigRules": [
+    {
+      "ConfigRuleName": "s3-bucket-public-read-prohibited",
+      "ConfigRuleArn": "arn:aws:config:us-east-1:416700587965:config-rule/config-rule-k8hsdv",
+      "ConfigRuleId": "config-rule-k8hsdv",
+      "Description": "Checks that your Amazon S3 buckets do not allow public read access. The rule checks the Block Public Access settings, the bucket policy, and the bucket access control list (ACL).",
+      "Source": {
+        "Owner": "AWS",
+        "SourceIdentifier": "S3_BUCKET_PUBLIC_READ_PROHIBITED"
+      },
+      "ConfigRuleState": "ACTIVE",
+      "EvaluationModes": [
+        {
+          "Mode": "DETECTIVE"
+        }
+      ]
+    }
+  ],
+  "ResponseMetadata": {
+    "RequestId": "4f31d3e8-4a31-4f20-8815-ff31077f9b21",
+    "HTTPStatusCode": 200,
+    "HTTPHeaders": {
+      "x-amzn-requestid": "4f31d3e8-4a31-4f20-8815-ff31077f9b21",
+      "strict-transport-security": "max-age=86400",
+      "content-type": "application/x-amz-json-1.1",
+      "content-length": "536",
+      "date": "Tue, 30 Sep 2025 22:43:47 GMT"
+    },
+    "RetryAttempts": 0
+  }
+}

--- a/src/tests/iam_policies_sample.json
+++ b/src/tests/iam_policies_sample.json
@@ -1,0 +1,24 @@
+{
+  "AttachedPolicies": [
+    {
+      "PolicyName": "AWSConfigUserAccess",
+      "PolicyArn": "arn:aws:iam::aws:policy/AWSConfigUserAccess"
+    },
+    {
+      "PolicyName": "IAMReadOnlyAccess",
+      "PolicyArn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
+    }
+  ],
+  "IsTruncated": false,
+  "ResponseMetadata": {
+    "RequestId": "2cf48ba4-86e7-4af5-b0a4-35618e316910",
+    "HTTPStatusCode": 200,
+    "HTTPHeaders": {
+      "date": "Tue, 30 Sep 2025 22:43:47 GMT",
+      "x-amzn-requestid": "2cf48ba4-86e7-4af5-b0a4-35618e316910",
+      "content-type": "text/xml",
+      "content-length": "697"
+    },
+    "RetryAttempts": 0
+  }
+}

--- a/src/tests/test_fetch.py
+++ b/src/tests/test_fetch.py
@@ -1,0 +1,23 @@
+import boto3
+import json
+
+def main():
+    # Initialize clients
+    session = boto3.Session(profile_name="policy-test-user")
+    config = session.client("config", region_name="us-east-1")
+    iam = session.client("iam")
+
+    # Fetch IAM attached policies (first 10 only for test)
+    iam_policies = iam.list_attached_user_policies(UserName="policy-test-user")
+    with open("iam_policies_sample.json", "w") as f:
+        json.dump(iam_policies, f, indent=2, default=str)  # <-- default=str fixes datetime
+    print("Saved iam_policies_sample.json")
+
+    # Fetch AWS Config rules
+    config_rules = config.describe_config_rules()
+    with open("config_rules_sample.json", "w") as f:
+        json.dump(config_rules, f, indent=2, default=str)  # <-- same here
+    print("Saved config_rules_sample.json")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Retrieved:

IAM managed policies - called iam.list_attached_user_policies() listing the policies attached to the user as well as all AWS-managed policies in the account.

AWS Config rules - calling describe_config_rules() to verify Config API access

The script saved both IAM and Config outputs as JSON files

